### PR TITLE
Passing page size (width and height) to the OnLoadCompleteListener

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -734,8 +734,8 @@ public class PDFView extends RelativeLayout {
         }
 
         dragPinchManager.enable();
-
-        callbacks.callOnLoadComplete(pdfFile.getPagesCount());
+        SizeF size = pdfFile.getPageSize(defaultPage);
+        callbacks.callOnLoadComplete(pdfFile.getPagesCount(), size.getWidth(), size.getHeight());
 
         jumpTo(defaultPage, false);
     }

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/Callbacks.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/Callbacks.java
@@ -78,9 +78,9 @@ public class Callbacks {
         this.onLoadCompleteListener = onLoadCompleteListener;
     }
 
-    public void callOnLoadComplete(int pagesCount) {
+    public void callOnLoadComplete(int pagesCount, float pageWidth, float pageHeight) {
         if (onLoadCompleteListener != null) {
-            onLoadCompleteListener.loadComplete(pagesCount);
+            onLoadCompleteListener.loadComplete(pagesCount, pageWidth, pageHeight);
         }
     }
 

--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnLoadCompleteListener.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/listener/OnLoadCompleteListener.java
@@ -25,5 +25,5 @@ public interface OnLoadCompleteListener {
      * Called when the PDF is loaded
      * @param nbPages the number of pages in this PDF file
      */
-    void loadComplete(int nbPages);
+    void loadComplete(int nbPages, float pageWidth, float pageHeight);
 }


### PR DESCRIPTION
This is needed to get the first page real width and height (no canvas) on the OnLoadCompleteListener, to later use in the react-native component https://github.com/wonday/react-native-pdf, Fixes https://github.com/barteksc/AndroidPdfViewer/issues/742